### PR TITLE
Update header_code_snooper.py

### DIFF
--- a/header_code_snooper.py
+++ b/header_code_snooper.py
@@ -27,10 +27,6 @@ def scan_file(filename):
         f.write(HEADER)
         tree = ET.parse(filename)
         for element_path in header_elements:
-            for element in tree.findall(f"{element_path}//code", ns):
-                attributes = element.attrib
-                f.write(f"{element_path},{element.attrib['codeSystem']},{element.attrib['code']},{element.attrib['displayName']}\n")
-            #snippet for finding codeSystem attributes too, all codeSystems have a code, but not all code has codeSystem, e.g. languageCode 
             for element in tree.findall(f"{element_path}//*[@codeSystem]", ns):
                 attributes = element.attrib
                 f.write(f"{element_path},{element.attrib['codeSystem']},{element.attrib['code']},{element.attrib['displayName']}\n")


### PR DESCRIPTION
Changed for logic to search for attributes with codeSystems regardless of element tag, for example gender and race are not code elements, but AdministrativeGenderCode and RaceCode elements.